### PR TITLE
Noted major gotcha about require'ing clarify

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,17 @@ To active require `clarify`.
   require('clarify');
 ```
 
+
+## Important gotcha
+
+If you are using clarify with a module to increase the size of the stacktrace such as trace or superstack), make sure you require it before clarify. i.e.
+```JavaScript
+  require('trace');
+  require('clarify');
+```
+Node will throw a "RangeError: Maximum call stack size exceeded" error if you try to require a stacktrace enhancer.after clarify.
+
+
 ## License
 
 **The software is license under "MIT"**


### PR DESCRIPTION
Added a warning about where in a file to require clarify when using it with other stacktrace modifying modules - likely a common use case, since this is where clarify really shines. 

This issue caused me a lot of headache when using clarify in my gulpfile, so I figure the warning would be handy to have in the README.