### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#clarify [![Build Status](https://secure.travis-ci.org/AndreasMadsen/clarify.png)](http://travis-ci.org/AndreasMadsen/clarify)
+# clarify [![Build Status](https://secure.travis-ci.org/AndreasMadsen/clarify.png)](http://travis-ci.org/AndreasMadsen/clarify)
 
 > Remove nodecore related stack trace noise
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
