### PR TITLE
Add support for Node.js v20

### DIFF
--- a/clarify.js
+++ b/clarify.js
@@ -6,6 +6,6 @@ const sep = require('path').sep;
 chain.filter.attach(function (error, frames) {
   return frames.filter(function (callSite) {
     const name = callSite && callSite.getFileName();
-    return (name && name.includes(sep) && !name.startsWith('internal'));
+    return (name && name.includes(sep) && !(name.startsWith('internal') || name.startsWith('node:internal')));
   });
 });


### PR DESCRIPTION
The recent versions of Node.js report their internal modules as `node:internal/*`. 

This PR adds that behavior to the filter.